### PR TITLE
Improved installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,43 +10,11 @@ __This bundle is a joke. Please do not use.__
 
 ## Installation
 
-### Step 1) Get the bundle
+First, grab sfContextBundle using [Composer](http://getcomposer.org/):
 
-First, grab sfContextBundle. There are two different ways to do this:
+    composer require francisbesset/sfContextBundle:~1.0
 
-#### Method a) Using composer (symfony 2.1 pattern)
-
-Run the following command to add the package to your composer.json
-(see http://getcomposer.org/):
-
-``` bash
-$ php composer.phar require francisbesset/sfContextBundle:dev-master
-```
-
-#### Method b) Using the `deps` file (symfony 2.0 pattern)
-
-Add the following lines to your `deps` file and then run `php bin/vendors
-install`:
-
-    [sfContextBundle]
-        git=https://github.com/francisbesset/sfContextBundle.git
-        target=bundles/sfContextBundle
-
-You should then add the `sfContextBundle` namespace to your autoloader:
-
-``` php
-<?php
-// app/autoload.php
-
-$loader->registerNamespaces(array(
-    // ...
-    'sfContextBundle' => __DIR__.'/../vendor/bundles',
-));
-```
-
-### Step 2) Register the bundle
-
-Finally, enable the bundle in the kernel:
+Then register the bundle in the kernel:
 
 ``` php
 <?php


### PR DESCRIPTION
Symfony 2.0 should now only be a nightmare long forgotten, so here's a composer only installation usage. Also I've used the recent `1.0.0` tag, so people won't need to download the internet when running `composer update` (`dev-master` is never cached by Composer).
